### PR TITLE
Integrate pdf_tools blueprint and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,19 @@ Start the server using the provided script:
 ./src/pdf_tools_service/run.sh
 ```
 
-The server listens on `http://localhost:8000`. Navigate to `/merge` or `/extract` to use the tools. When used alongside `ml_server`, point requests to the same endpoints.
+The server listens on `http://HOST:PORT` (default `0.0.0.0:8000`). Navigate to
+`/pdf_tools/merge` or `/pdf_tools/extract` to use the tools. When integrated
+with `ml_server`, mount the blueprint under the same prefix.
+
+Configuration is loaded from `src/pdf_tools_service/config.json` by default. A
+different path can be provided using the `PDF_TOOLS_CONFIG` environment
+variable or as the first argument to `run.sh` and `setup.sh`.
 
 ## Development
 
 The original documentation describing the project structure and configuration lives in [src/pdf_tools_service/README.md](src/pdf_tools_service/README.md). New features should include matching tests under `tests/`.
+
+For intranet deployment details see [docs/INTRANET_DEPLOYMENT.md](docs/INTRANET_DEPLOYMENT.md).
 
 ## License
 

--- a/docs/INTRANET_DEPLOYMENT.md
+++ b/docs/INTRANET_DEPLOYMENT.md
@@ -1,0 +1,29 @@
+# Intranet Deployment
+
+This service can run stand alone or as a blueprint under the `ml_server`
+application.
+
+## Standalone testing
+
+```bash
+./src/pdf_tools_service/setup.sh
+./src/pdf_tools_service/run.sh
+```
+
+Visit `http://localhost:8000/pdf_tools/merge` to test the interface.
+
+## Using with ml_server
+
+Import `create_app` from `pdf_tools_service.app` and register the
+`pdf_tools` blueprint on the main Flask app:
+
+```python
+from pdf_tools_service.app import pdf_tools_bp
+app.register_blueprint(pdf_tools_bp)
+```
+
+Configuration can be overridden via environment variables prefixed with
+`PDFTOOLS_` or by setting `PDF_TOOLS_CONFIG` to a config file path.
+
+Health checks are available at `/pdf_tools/health` and Prometheus metrics at
+`/pdf_tools/metrics`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,14 @@ dependencies = [
     "PyPDF2",
     "pdf2image",
     "WTForms",
-    "Pillow"
+    "Pillow",
+    "prometheus_client"
+]
+
+[tool.setuptools.package-data]
+pdf_tools_service = [
+    "app/templates/*.html",
+    "app/static/**/*",
 ]
 
 [tool.flask]

--- a/src/pdf_tools_service/__main__.py
+++ b/src/pdf_tools_service/__main__.py
@@ -1,4 +1,10 @@
-from .app import app
+import os
+
+from .app import create_app
+
+app = create_app(os.getenv("PDF_TOOLS_CONFIG"))
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=8000)
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "8000"))
+    app.run(host=host, port=port)

--- a/src/pdf_tools_service/app/__init__.py
+++ b/src/pdf_tools_service/app/__init__.py
@@ -1,32 +1,97 @@
 """Application factory for the PDF Tools service."""
 
+from __future__ import annotations
+
 import json
 import os
-from flask import Flask, render_template
+from flask import Flask, Blueprint, render_template, jsonify
 
 
-DEFAULT_CONFIG = os.path.join(os.path.dirname(__file__), '..', 'config.json')
+DEFAULT_CONFIG = os.path.join(os.path.dirname(__file__), "..", "config.json")
+
+# parent blueprint exported for integration with other apps
+pdf_tools_bp = Blueprint("pdf_tools", __name__, url_prefix="/pdf_tools")
+
+from .controllers.merge_controller import merge_bp
+from .controllers.extract_controller import extract_bp
+from .services.metrics import request_latency, request_count, metrics_response
+
+pdf_tools_bp.register_blueprint(merge_bp)
+pdf_tools_bp.register_blueprint(extract_bp)
 
 
-def create_app(config_path: str = DEFAULT_CONFIG) -> Flask:
+@pdf_tools_bp.route("/")
+def index() -> str:
+    """Render the landing page."""
+
+    return render_template("index.html")
+
+
+@pdf_tools_bp.route("/health")
+def health():
+    """Health check endpoint."""
+
+    return jsonify({"status": "ok"})
+
+
+@pdf_tools_bp.route("/metrics")
+def metrics():
+    return metrics_response()
+
+
+def _load_config(path: str) -> dict:
+    """Load JSON configuration applying environment overrides."""
+
+    with open(path) as cfg:
+        config = json.load(cfg)
+
+    prefix = "PDFTOOLS_"
+    for key, value in os.environ.items():
+        if not key.startswith(prefix):
+            continue
+        parts = key[len(prefix) :].lower().split("__")
+        dest = config
+        for part in parts[:-1]:
+            dest = dest.setdefault(part, {})
+        try:
+            dest[parts[-1]] = json.loads(value)
+        except Exception:
+            dest[parts[-1]] = value
+
+    return config
+
+
+def create_app(config_path: str | None = None) -> Flask:
     """Create and configure the Flask application."""
 
+    config_path = config_path or os.getenv("PDF_TOOLS_CONFIG", DEFAULT_CONFIG)
+
     app = Flask(__name__)
-    with open(config_path) as cfg:
-        config = json.load(cfg)
-    app.config.update(config)
+    app.config.update(_load_config(config_path))
 
-    from .controllers.merge_controller import merge_bp
-    from .controllers.extract_controller import extract_bp
 
-    app.register_blueprint(merge_bp)
-    app.register_blueprint(extract_bp)
+    @app.before_request
+    def _start_timer():
+        from flask import g, request
+        import time
 
-    @app.route('/')
-    def index():
-        """Render the landing page."""
+        g._metric_path = request.path
+        g._metric_start = time.time()
 
-        return render_template('index.html')
+    @app.after_request
+    def _end_timer(response):
+        from flask import g, request
+
+        if hasattr(g, "_metric_start") and hasattr(g, "_metric_path"):
+            import time
+            duration = time.time() - g._metric_start
+            request_latency.labels(g._metric_path).observe(duration)
+            request_count.labels(g._metric_path, response.status_code).inc()
+        else:
+            request_count.labels(request.path, response.status_code).inc()
+        return response
+
+    app.register_blueprint(pdf_tools_bp)
 
     return app
 

--- a/src/pdf_tools_service/app/services/metrics.py
+++ b/src/pdf_tools_service/app/services/metrics.py
@@ -1,0 +1,26 @@
+"""Prometheus metrics helpers for pdf_tools."""
+
+from __future__ import annotations
+
+from prometheus_client import Counter, Histogram, generate_latest
+
+request_latency = Histogram(
+    "pdf_tools_request_latency_seconds",
+    "Request latency in seconds",
+    ["endpoint"],
+)
+
+request_count = Counter(
+    "pdf_tools_request_total",
+    "Total HTTP requests",
+    ["endpoint", "status"],
+)
+
+
+def metrics_response():
+    """Return metrics for Prometheus scraping."""
+    return (
+        generate_latest(),
+        200,
+        {"Content-Type": "text/plain; version=0.0.4"},
+    )

--- a/src/pdf_tools_service/app/templates/base.html
+++ b/src/pdf_tools_service/app/templates/base.html
@@ -9,9 +9,9 @@
 <body>
 <header>
     <nav>
-        <a href="/">Home</a>
-        <a href="/merge">Merge PDFs</a>
-        <a href="/extract">Extract Pages</a>
+        <a href="{{ url_for('pdf_tools.index') }}">Home</a>
+        <a href="{{ url_for('pdf_tools.merge.form') }}">Merge PDFs</a>
+        <a href="{{ url_for('pdf_tools.extract.form') }}">Extract Pages</a>
     </nav>
 </header>
 <main>

--- a/src/pdf_tools_service/app/templates/extract.html
+++ b/src/pdf_tools_service/app/templates/extract.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Extract Pages</h2>
-<form id="extract-form" method="post" enctype="multipart/form-data">
+<form id="extract-form" method="post" enctype="multipart/form-data" action="{{ url_for('pdf_tools.extract.extract') }}">
     <input type="file" name="file" required>
     <input type="text" name="range" placeholder="Page range (e.g., 1-5)" value="1" title="Pages to extract">
     <label><input type="checkbox" name="preview" value="1"> Preview</label>

--- a/src/pdf_tools_service/app/templates/merge.html
+++ b/src/pdf_tools_service/app/templates/merge.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Merge PDFs</h2>
-<form id="merge-form" method="post" enctype="multipart/form-data">
+<form id="merge-form" method="post" enctype="multipart/form-data" action="{{ url_for('pdf_tools.merge.merge') }}">
     <div id="files"></div>
     <button type="button" id="add-file">Add File</button>
     <label>Output name: <input type="text" name="output_name" value="merged.pdf"></label>

--- a/src/pdf_tools_service/deployment_intranet.md
+++ b/src/pdf_tools_service/deployment_intranet.md
@@ -6,5 +6,9 @@ These instructions assume an offline intranet environment.
 2. Set up a Python virtual environment.
 3. Use `gunicorn` with systemd to run the app on `0.0.0.0:8000`.
 4. Configure your intranet DNS to route traffic to the server.
+5. Optionally configure Prometheus to scrape `/pdf_tools/metrics` for basic
+   request statistics.
 
-See `setup.sh` for required packages and `run.sh` for the launch command.
+Use `setup.sh /path/to/config.json` to create the environment and
+`gunicorn.sh /path/to/config.json` for production serving. For ad-hoc testing
+the `run.sh` script can also be used.

--- a/src/pdf_tools_service/gunicorn.sh
+++ b/src/pdf_tools_service/gunicorn.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
-
-# Optional config path can be supplied as first argument
 CONFIG_PATH=${1:-$PDF_TOOLS_CONFIG}
 export PDF_TOOLS_CONFIG="$CONFIG_PATH"
-
 export HOST=${HOST:-0.0.0.0}
 export PORT=${PORT:-8000}
-
 source venv/bin/activate
-exec python -m pdf_tools_service
+exec gunicorn -b "$HOST:$PORT" "pdf_tools_service.app:app"

--- a/src/pdf_tools_service/requirements.txt
+++ b/src/pdf_tools_service/requirements.txt
@@ -3,3 +3,4 @@ PyPDF2
 pdf2image
 WTForms
 Pillow
+prometheus_client

--- a/src/pdf_tools_service/setup.sh
+++ b/src/pdf_tools_service/setup.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Optional config path as first argument for later use
+CONFIG_PATH=${1:-$PDF_TOOLS_CONFIG}
+export PDF_TOOLS_CONFIG="$CONFIG_PATH"
+
 python3 -m venv venv
 source venv/bin/activate
 pip install --upgrade pip

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,34 @@
+import io
+from flask import url_for
+
+
+def test_health_endpoint(client):
+    resp = client.get('/pdf_tools/health')
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "ok"}
+
+
+def test_metrics_endpoint(client):
+    resp = client.get('/pdf_tools/metrics')
+    assert resp.status_code == 200
+    assert b'pdf_tools_request_total' in resp.data
+
+
+def test_merge_route(client, sample_pdf):
+    data = {
+        'file0': (io.BytesIO(sample_pdf), 'a.pdf'),
+        'range_file0': 'all',
+    }
+    resp = client.post('/pdf_tools/merge', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 200
+    assert resp.get_json()['success'] is True
+
+
+def test_extract_route(client, sample_pdf):
+    data = {
+        'file': (io.BytesIO(sample_pdf), 'a.pdf'),
+        'range': '1',
+    }
+    resp = client.post('/pdf_tools/extract', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 200
+    assert resp.get_json()['success'] is True


### PR DESCRIPTION
## Summary
- expose pdf_tools as a single blueprint with `/pdf_tools` prefix
- add health and metrics endpoints
- track request metrics via prometheus client
- allow config via env var and use HOST/PORT envs
- document intranet deployment and standalone usage
- update run/setup scripts and add gunicorn script
- include templates/static as package data
- add tests for new routes

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c69c2d6bc8324ac329a524ac611df